### PR TITLE
mqtt is made disconnect properly (or so it seems)

### DIFF
--- a/Source/CocoaMQTT.swift
+++ b/Source/CocoaMQTT.swift
@@ -192,6 +192,9 @@ open class CocoaMQTT: NSObject, CocoaMQTTClient, CocoaMQTTFrameBufferProtocol {
 
     fileprivate func send(_ frame: CocoaMQTTFrame, tag: Int = 0) {
         let data = frame.data()
+        guard socket != nil else {
+            return
+        }
         socket!.write(Data(bytes: data, count: data.count), withTimeout: -1, tag: tag)
     }
 
@@ -307,7 +310,9 @@ open class CocoaMQTT: NSObject, CocoaMQTTClient, CocoaMQTTFrameBufferProtocol {
     /// disconnect unexpectedly
     open func internal_disconnect() {
         send(CocoaMQTTFrame(type: CocoaMQTTFrameType.disconnect), tag: -0xE0)
+        socket?.delegate = nil
         socket!.disconnect()
+        socket = nil
     }
 }
 


### PR DESCRIPTION
This solves the issue of mqtt keeps disconnecting and connecting again.

I have a problem here when disconnect mqtt and reconnect immediately, say within 2 seconds, it then keeps disconnecting and reconnecting over and over again. I am not completely sure what is the cause of it but this for now solves my problem. It seems to me that mqtt is not properly disconnected based on the documentation